### PR TITLE
Fix the value of the PROVIDER_PACKAGE_NAME env. variable for updoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,16 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
         with:

--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -63,22 +63,21 @@ jobs:
       - name: Upload Docs
         env:
           GOOGLE_APPLICATION_CREDENTIALS: sa.json
-          PROVIDER_NAME: ${GITHUB_REPOSITORY#*/}
           VER_MAJOR_MINOR: v${GITHUB_REF#"refs/heads/release-"}
           SUBPACKAGES: ${{ inputs.providers }}
         run: |
           if [[ "${GITHUB_REF##*/}" == release-* ]]; then
             for s in $SUBPACKAGES; do
-              PROVIDER_PACKAGE_NAME="${PROVIDER_NAME/-upjet/}-$s"
+              PROVIDER_PACKAGE_NAME="provider-${GITHUB_REPOSITORY##*-}-${s}"
               DOCS_DIR="./docs/family"
                 if [ $s == 'monolith' ]; then
-                  PROVIDER_PACKAGE_NAME="${PROVIDER_NAME/-upjet/}"
+                  PROVIDER_PACKAGE_NAME="provider-${GITHUB_REPOSITORY##*-}"
                   DOCS_DIR="./docs/monolith"
                 elif [ $s == 'config' ]; then
                   PROVIDER_PACKAGE_NAME="provider-family-${GITHUB_REPOSITORY##*-}"
                   DOCS_DIR="./docs/family"
                 fi
-                echo "Publishing Docs for $PROVIDER_PACKAGE_NAME, ${{ env.VER_MAJOR_MINOR }} from $DOCS_DIR"
+                echo "Publishing Docs for ${PROVIDER_PACKAGE_NAME}, ${{ env.VER_MAJOR_MINOR }} from $DOCS_DIR"
                 go run github.com/upbound/uptest/cmd/updoc@${{ env.UPTEST_VERSION }} upload --docs-dir="${DOCS_DIR}" --name="${PROVIDER_PACKAGE_NAME}" --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
             done
           else


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We've realized that the marketplace docs for `upbound/provider-azuread@v1.0.0` and (previously) for `upbound/provider-aws@v1.2.0` are not available although the family provider docs are there. This PR attempts to fix the package name calculation. It turns out that the `PROVIDER_NAME`'s value was not properly substituted.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
We will directly test in the official providers' CI pipelines.