### PR TITLE
[updoc] Check for errors while walking the filesystem

### DIFF
--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -13,12 +13,14 @@ on:
         default: '1.20'
         required: false
         type: string
+      updoc-version:
+        description: 'updoc version to use while publishing the documentation'
+        default: '83bd901'
+        required: false
+        type: string
     secrets:
       UPBOUND_CI_PROD_BUCKET_SA:
         required: true
-
-env:
-  UPTEST_VERSION: "83bd901"
 
 jobs:
   publish-docs:
@@ -78,7 +80,7 @@ jobs:
                   DOCS_DIR="./docs/family"
                 fi
                 echo "Publishing Docs for ${PROVIDER_PACKAGE_NAME}, ${{ env.VER_MAJOR_MINOR }} from $DOCS_DIR"
-                go run github.com/upbound/uptest/cmd/updoc@${{ env.UPTEST_VERSION }} upload --docs-dir="${DOCS_DIR}" --name="${PROVIDER_PACKAGE_NAME}" --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
+                go run github.com/upbound/uptest/cmd/updoc@${{ inputs.updoc-version }} upload --docs-dir="${DOCS_DIR}" --name="${PROVIDER_PACKAGE_NAME}" --version=${{ env.VER_MAJOR_MINOR }} --bucket-name=bucket-marketplace-docs-production --cdn-domain=https://user-content.upbound.io
             done
           else
             echo "This job can only be run on release branches"

--- a/.github/workflows/provider-updoc.yml
+++ b/.github/workflows/provider-updoc.yml
@@ -15,7 +15,7 @@ on:
         type: string
       updoc-version:
         description: 'updoc version to use while publishing the documentation'
-        default: '83bd901'
+        default: '21481764'
         required: false
         type: string
     secrets:

--- a/internal/updoc/upload.go
+++ b/internal/updoc/upload.go
@@ -119,6 +119,9 @@ func (u *UploadManager) getIndex(afs afero.Fs, dir string, meta map[string]strin
 func (u *UploadManager) getMeta(ctx context.Context, bucket *storage.BucketHandle, cdn string, afs afero.Fs, dir string) (map[string]string, error) {
 	meta := make(map[string]string)
 	if err := afero.Walk(afs, dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			if info.Name() == indexFN || info.Name() == sectionFN {
 				return nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
@turkenf hit [an issue](https://github.com/upbound/provider-terraform/actions/runs/8562381218) while trying to publish marketplace documents of the `upbound/provider-terraform` repository. 

We've identified the configuration error in that repository to resolve that issue but we've also spotted an error checking bug in `updoc`. This PR adds an error check while walking the filesystem to discover the docs to be published. 

It also parameterizes the `updoc` version that a provider repo is using and sets the default to a version containing the new fix.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Locally reproduced the configuration issue and we now log the underlying error:
```shell
2024/04/05 17:20:35 lstat ./docs/monolith: no such file or directory
```