### PR TITLE
Fix runner selection by full switch to e2-standard-8

### DIFF
--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -343,7 +343,7 @@ jobs:
         run: make local-deploy
 
   publish-artifacts:
-    runs-on: [e2-standard-8, linux]
+    runs-on: e2-standard-8
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 

--- a/.github/workflows/provider-publish-service-artifacts.yml
+++ b/.github/workflows/provider-publish-service-artifacts.yml
@@ -62,7 +62,7 @@ env:
   
 jobs:
   index:
-    runs-on: [e2-standard-8, linux]
+    runs-on: e2-standard-8
     outputs:
       indices: ${{ steps.calc.outputs.indices }}
     steps:
@@ -76,7 +76,7 @@ jobs:
         index: ${{ fromJSON(needs.index.outputs.indices) }}
 
     needs: index
-    runs-on: [e2-standard-8, linux]
+    runs-on: e2-standard-8
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1


### PR DESCRIPTION

<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

* Multiple labels of [e2-standard-8, linux] do not work anymore for an unknown external reason

Fix dependant official provider workflows like https://github.com/upbound/provider-terraform/actions/runs/9718945831/job/26827846240

<img width="968" alt="image" src="https://github.com/upbound/official-providers-ci/assets/518532/63e09bcf-93f5-449a-a017-fbafccf4fbb7">

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Previous PRs unblocked the pipelines
