### PR TITLE
Add nil check before filterAnnotations func in cleanupexamples tool

### DIFF
--- a/cmd/cleanupexamples/main.go
+++ b/cmd/cleanupexamples/main.go
@@ -81,6 +81,10 @@ func processYAML(yamlData []byte) ([]byte, error) {
 			return nil, fmt.Errorf("cannot decode the YAML file: %w", err)
 		}
 
+		if u == nil {
+			continue
+		}
+
 		// Remove specific annotations from the decoded Kubernetes object.
 		filterAnnotations(u)
 


### PR DESCRIPTION
### Description of your changes

This PR adds nil check before `filterAnnotations` func in `cleanupexamples` tool due to `panic: runtime error: invalid memory address or nil pointer dereference` issue.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually with OP examples locally.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
