### PR TITLE
Add UPBOUND_GITHUB_BOT_TOKEN to publish provider pipeline

### DIFF
--- a/.github/workflows/publish-provider-family.yml
+++ b/.github/workflows/publish-provider-family.yml
@@ -117,6 +117,7 @@ jobs:
           submodules: true
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
+          token: ${{ secrets.UPBOUND_GITHUB_BOT_TOKEN }}
 
       - name: Fetch History
         run: git fetch --prune --unshallow


### PR DESCRIPTION
### Description of your changes

Adds UPBOUND_GITHUB_BOT_TOKEN to publish provider pipeline

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
