### PR TITLE
Add github bot token to scan workflow as optional

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,6 +10,10 @@ on:
         description: 'Number of supported releases'
         type: number
         default: 1
+    secrets:
+      TOKEN:
+        description: 'Github token to use, optional'
+        required: false
 
 env:
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
@@ -26,7 +30,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.UPBOUND_GITHUB_BOT_TOKEN }}
+          token: ${{ secrets.TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Get Last Release
         id: get-releases


### PR DESCRIPTION
### Description of your changes

Add github bot token to scan workflow as optional. Here we pass the token secret and if it is not given we use the existing github token in the repos.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually `turkenf/provider-opentofu`

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
