### PR TITLE
Add docker username and password to secrets workflow

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -14,6 +14,12 @@ on:
       TOKEN:
         description: 'Github token to use, optional'
         required: false
+      DOCKER_USR:
+        description: 'Docker username'
+        required: false
+      DOCKER_PSW:
+        description: 'Docker password'
+        required: false
 
 env:
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
@@ -130,6 +136,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
+          registry: xpkg.upbound.io
 
       # we pull the image to be sure we're scanning the latest sha available
       - name: Pull Latest Image
@@ -154,4 +161,4 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
           category: ${{ matrix.image }}:${{ env.tag }}
-
+          token: ${{ secrets.TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description of your changes

In this PR:

- Adds docker username and password to secrets workflow
- Adds `registry: xpkg.upbound.io` parameter to docker login step.
- Adds token to `Upload Trivy Scan Results To GitHub Security Tab` step

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested `turkenf/provider-opentofu` and `turkenf/provider-family-gcp-beta`. Only the `Upload Trivy Scan Results To GitHub Security Tab` step could not be tested, as it is available for the organization.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
