### PR TITLE
Parametrize pr-comment-trigger(e2e) runs-on

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -32,6 +32,10 @@ on:
         default: ''
         required: false
         type: string
+      runs-on:
+        default: e2-standard-8
+        required: false
+        type: string
     secrets:
       UPTEST_CLOUD_CREDENTIALS:
         description: 'Uptest cloud credentials to be passed to the uptest target as environment variable'
@@ -42,7 +46,7 @@ on:
 
 jobs:
   debug:
-    runs-on: e2-standard-8
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Debug
         run: |
@@ -54,7 +58,7 @@ jobs:
     if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
             github.event.issue.pull_request &&
             contains(github.event.comment.body, inputs.trigger-keyword ) }}
-    runs-on: e2-standard-8
+    runs-on: ${{ inputs.runs-on }}
     outputs:
       example_list: ${{ steps.get-example-list-name.outputs.example-list }}
       example_hash: ${{ steps.get-example-list-name.outputs.example-hash }}
@@ -111,7 +115,7 @@ jobs:
     if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, inputs.trigger-keyword ) }}
-    runs-on: e2-standard-8
+    runs-on: ${{ inputs.runs-on }}
     needs: get-example-list
 
     steps:


### PR DESCRIPTION


<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Currently, we have a hardcoded self-hosted runner label that is specific to upbound
* It blocks the reusable workflow adoption outside of upbound

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Please see test results in my fork of configuration-app where I tested this change end-to-end
https://github.com/ytsarev/configuration-app/pull/1
