### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Publish Artifacts to GitHub
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: output
           path: _output/**

--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload Cluster Dump
         if: always()
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: controlplane-dump
           path: ./_output/controlplane-dump

--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -219,7 +219,7 @@ jobs:
         run: head -1 _output/skipped_resources.csv
 
       - name: Publish skipped resources CSV to Github
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: skipped_resources
           path: _output/skipped_resources.csv
@@ -422,7 +422,7 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Upload Artifacts to GitHub
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: output
           path: _output/**

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -150,7 +150,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: trivy-${{ env.escaped_filename }}.sarif
           path: trivy-results.sarif


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Currently all uptests seems to be broken. V3 of actions/upload-artifact was deprectaed some while ago and is no longer functioning. See https://github.com/upbound/configuration-aws-database/actions/runs/12813248983/job/35726896148

### How has this code been tested

Could not find a good way of testing it so far because it needs to be in master for consuming repos. Maybe someone has a good way of testing it.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
