### PR TITLE
crddiff: Look up version by name, not array index

### DIFF
--- a/internal/crdschema/crd.go
+++ b/internal/crdschema/crd.go
@@ -280,13 +280,22 @@ func (d *RevisionDiff) GetBreakingChanges() (map[string]*diff.Diff, error) {
 	}
 
 	diffMap := make(map[string]*diff.Diff, len(baseDocs))
-	for i, baseDoc := range baseDocs {
+	for _, baseDoc := range baseDocs {
 		versionName := baseDoc.Info.Version
-		if i >= len(revisionDocs) || revisionDocs[i].Info.Version != versionName {
+		var revisionDoc *openapi3.T
+		for _, r := range revisionDocs {
+			if r.Info.Version == versionName {
+				revisionDoc = r
+				break
+			}
+		}
+
+		if revisionDoc == nil {
 			// no corresponding version to compare in the revision
 			return nil, errors.Errorf("revision has no corresponding version to compare with the base for the version name: %s", versionName)
 		}
-		sd, err := schemaDiff(baseDoc, revisionDocs[i])
+
+		sd, err := schemaDiff(baseDoc, revisionDoc)
 		if err != nil {
 			return nil, errors.Wrap(err, errBreakingRevisionChangesCompute)
 		}

--- a/internal/crdschema/crd_test.go
+++ b/internal/crdschema/crd_test.go
@@ -173,6 +173,17 @@ func Test_GetRevisionBreakingChanges(t *testing.T) {
 				},
 			},
 		},
+		"Unordered": {
+			reason: "No diff should be reported if the order of versions is different",
+			args: args{
+				basePath: "testdata/base.yaml",
+				revisionModifiers: []crdModifier{
+					func(r *v1.CustomResourceDefinition) {
+						r.Spec.Versions[0], r.Spec.Versions[1] = r.Spec.Versions[1], r.Spec.Versions[0]
+					},
+				},
+			},
+		},
 		"ExistingEnumConstantRemovedInRevision": {
 			reason: "Removing an existing enum constant is a breaking API change",
 			args: args{


### PR DESCRIPTION
### Description of your changes

When crddiff looked for a specific api version, it checked the new CRD
using array indexing. This fails for example when checking crossplane
1.16 to 1.17, where 1.16 has [v1beta1] and 1.17 has [v1, v1beta1]:

  go run ./cmd/crddiff/ revision crossplane-1.16/cluster/crds/pkg.crossplane.io_functions.yaml crossplane-1.17/cluster/crds/pkg.crossplane.io_functions.yaml
  crddiff: error: Failed to compute CRD breaking API changes: revision has no corresponding version to compare with the base for the version name: v1beta1

This does not fix a specific issue but makes itmore usable to compare
different versions of CRDs for provider and core crossplane releases.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.


### How has this code been tested

Unit test and against 1.16 -> 1.17 crossplane CRD diff.
