### PR TITLE
[release-0.12]: Prevent external contributors from triggering workflows via PR comments

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -51,7 +51,7 @@ jobs:
           echo "github.event.comment.author_association: ${{ github.event.comment.author_association }}"
 
   get-example-list:
-    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
+    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
             github.event.issue.pull_request &&
             contains(github.event.comment.body, inputs.trigger-keyword ) }}
     runs-on: e2-standard-8
@@ -108,7 +108,7 @@ jobs:
             -f context="Uptest-${{ steps.get-example-list-name.outputs.example-hash }}"
 
   uptest:
-    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
+    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, inputs.trigger-keyword ) }}
     runs-on: e2-standard-8


### PR DESCRIPTION
### Description of your changes

This PR prevents external contributors from triggering workflows via PR comments to mitigate security risk.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested