### PR TITLE
Fix missing sha on status checks when run via label

### DIFF
--- a/.github/workflows/pr-comment-trigger.yml
+++ b/.github/workflows/pr-comment-trigger.yml
@@ -96,8 +96,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${EVENT_NAME}" == "issue_comment" ]; then
+          if [ "${{ github.event_name }}" == "issue_comment" ]; then
             gh pr checkout ${{ github.event.issue.number }}
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            gh pr checkout ${{ github.event.pull_request.number }}
           fi
           git submodule update --init --recursive
           OUTPUT=$(git log -1 --format='%H')
@@ -169,12 +171,16 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Checkout PR
-        if: ${{ github.event_name == 'issue_comment' }}
+        if: ${{ github.event_name == 'issue_comment' }} || ${{ github.event_name == 'pull_request' }}
         id: checkout-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr checkout ${{ github.event.issue.number }}
+          if [ "${{ github.event_name }}" == "issue_comment" ]; then
+            gh pr checkout ${{ github.event.issue.number }}
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            gh pr checkout ${{ github.event.pull_request.number }}
+          fi
           git submodule update --init --recursive
           OUTPUT=$(git log -1 --format='%H')
           echo "commit-sha=$OUTPUT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
Thank you for helping to improve Uptest!

Please read through https://git.io/fj2m9 if this is your first time opening an
Uptest pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When run via label, the status-check reporting via gh api failed with a 404. This was because of a missing sha caused by improper handling of the github event when triggered via label.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Uptest issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

### How has this code been tested

Verified in my own fork: https://github.com/kaessert/configuration-app/actions/runs/15157190978/job/42614691839

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
